### PR TITLE
aanpassingen naar design en animatie fix #41

### DIFF
--- a/public/css/popup.css
+++ b/public/css/popup.css
@@ -1,3 +1,8 @@
+ body{
+    --popup-pink:#E90166;
+    --popup-blue:#0076D1;
+ }
+
  .popup {
      overflow: visible;
      position: fixed;
@@ -12,7 +17,7 @@
 
      border: none;
      border-radius: 10px;
-     box-shadow: 10px 20px 50px #000;
+     box-shadow: 10px 20px 50px var(--popup-dark);
 
      transition-behavior: allow-discrete;
 
@@ -69,8 +74,8 @@
      top: -0.8em;
      left: 50%;
      transform: translateX(-50%);
-     background: #FE0170;
-     color: white;
+     background: var(--popup-pink);
+     color: var(--color-white);
      padding: 0.25em 0.5em;
      border-radius: 5px;
      z-index: 10;
@@ -103,10 +108,11 @@
  .popup-button {
      flex: 1 1 50%;
      min-width: 0;
+     font-weight: bold;
      height: 2.5em;
      border: none;
-     background: #007acc;
-     color: white;
+     background: var(--popup-blue);
+     color: var(--color-white);
      cursor: pointer;
 
      transition: flex 0.2s ease-in-out, opacity 0.2s linear;
@@ -115,7 +121,7 @@
 
  .popup-button:first-child {
      border-radius: 0 0 0 5px;
-     background-color: #FE0170;
+     background-color: var(--popup-pink);
  }
 
  .popup-buttons:hover .popup-button:not(:hover) {
@@ -129,30 +135,3 @@
  .popup-button:focus {
      flex: 1 1 100%;
  }
-
-
-
-
- /* .popup-buttons {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-
-        .popup-button:first-child {
-            grid-column: 1/1;
-
-        }
-
-        .popup-button:last-child {
-            grid-column: 2/2;
-        }
-
-        .popup-button:hover {
-            grid-column: 1/-1;
-        }
-
-        &:has(.popup-button:hover) {
-            .popup-button:not(:hover) {
-                display: none;
-            }
-        }
-    } */

--- a/public/css/popup.css
+++ b/public/css/popup.css
@@ -27,14 +27,19 @@
      }
  }
 
- .info-wrapper {
+ dl {
      display: flex;
-     flex-direction: row;
+     flex-wrap: wrap;
  }
 
+ dt {
+     width: 1rem;
+     margin-right: 1rem;
+ }
 
  dd {
-     margin: 0;
+     margin-left: auto;
+     width: calc(100% - 2rem)
  }
 
  @supports not selector([]) {
@@ -71,20 +76,20 @@
      z-index: 10;
  }
 
- .popup picture img{
+ .popup picture img {
      border-radius: 50%;
      width: 70px;
      height: auto;
  }
 
- @media (min-width:500px){
-    .popup picture img{
-     width: 120px;
-    }
+ @media (min-width:500px) {
+     .popup picture img {
+         width: 120px;
+     }
  }
 
  .popup-title {
-     margin-bottom:1em;
+     margin-bottom: 1em;
  }
 
  .popup-buttons {
@@ -116,10 +121,12 @@
  .popup-buttons:hover .popup-button:not(:hover) {
      flex: 0 1 0;
      pointer-events: none;
-     color: #00000000; /* ontzichtbaar maken van de tekst in button voor een soepele overgang */
+     color: #00000000;
+     /* ontzichtbaar maken van de tekst in button voor een soepele overgang */
  }
 
- .popup-button:hover, .popup-button:focus {
+ .popup-button:hover,
+ .popup-button:focus {
      flex: 1 1 100%;
  }
 

--- a/public/css/popup.css
+++ b/public/css/popup.css
@@ -1,117 +1,132 @@
  .popup {
-        overflow: visible;
-        position: absolute;
-        left: 50%;
-        top: 50%;
-        transform: translate(-50%, -50%);
+     overflow: visible;
+     position: fixed;
+     left: 50%;
+     top: 90%;
+     transform: translate(-50%, -90%);
 
-        z-index: 999;
-        width: 90%;
-        min-width: 200px;
-        max-width: 400px;
+     z-index: 999;
+     width: 80%;
+     min-width: 200px;
+     max-width: 400px;
 
-        border: none;
-        border-radius: 10px;
-        box-shadow: 10px 20px 50px #e7e7e7;
+     border: none;
+     border-radius: 10px;
+     box-shadow: 10px 20px 50px #000;
 
+     transition-behavior: allow-discrete;
+
+ }
+
+ @media (min-width: 800px) {
+     .popup {
+         left: 95%;
+         top: 95%;
+         transform: translate(-95%, -95%);
+
+     }
+ }
+
+ .info-wrapper {
+     display: flex;
+     flex-direction: row;
+ }
+
+
+ dd {
+     margin: 0;
+ }
+
+ @supports not selector([]) {
+
+     /*support voor de selector*/
+     [popover] {
+         /* standaard openklappen */
+         display: block;
+     }
+
+     [popover]:popover-open {
+         /*als op de knop word gedrukt sluiten*/
+         display: none;
+     }
+ }
+
+ .popup-layout {
+     display: flex;
+     flex-flow: row wrap;
+     justify-content: start;
+     gap: 1em;
+     padding: 2rem 1rem 0 1rem;
+ }
+
+ .popup-status {
+     position: absolute;
+     top: -0.8em;
+     left: 50%;
+     transform: translateX(-50%);
+     background: #FE0170;
+     color: white;
+     padding: 0.25em 0.5em;
+     border-radius: 5px;
+     z-index: 10;
+ }
+
+ .popup picture img{
+     border-radius: 50%;
+     width: 70px;
+     height: auto;
+ }
+
+ @media (min-width:500px){
+    .popup picture img{
+     width: 120px;
     }
+ }
 
-    .info-wrapper {
-        display: flex;
-        flex-direction: row;
-    }
+ .popup-title {
+     margin-bottom:1em;
+ }
 
+ .popup-buttons {
+     margin-top: 1em;
+     display: flex;
+     width: 100%;
+     min-width: 0;
+     overflow: hidden;
+ }
 
+ .popup-button {
+     flex: 1 1 50%;
+     min-width: 0;
+     height: 2.5em;
+     border: none;
+     background: #007acc;
+     color: white;
+     cursor: pointer;
 
-    dd {
-        margin: 0;
-    }
+     transition: flex 0.2s ease-in-out, opacity 0.2s linear;
+     transition-behavior: allow-discrete;
+ }
 
-    @supports not selector([]) {
+ .popup-button:first-child {
+     border-radius: 0 0 0 5px;
+     background-color: #FE0170;
+ }
 
-        /*support voor de selector*/
-        [popover] {
-            /* standaard openklappen */
-            display: block;
-        }
+ .popup-buttons:hover .popup-button:not(:hover) {
+     flex: 0 1 0;
+     pointer-events: none;
+     color: #00000000; /* ontzichtbaar maken van de tekst in button voor een soepele overgang */
+ }
 
-        [popover]:popover-open {
-            /*als op de knop word gedrukt sluiten*/
-            display: none;
-        }
-    }
-
-    .popup-layout {
-        display: flex;
-        flex-flow: row wrap;
-        gap: 1em;
-
-        padding: 2rem 1rem 0 1rem;
-    }
-
-    .popup-status {
-        position: absolute;
-        top: -0.5em;
-        left: 50%;
-        transform: translateX(-50%);
-        background: #FE0170;
-        color: white;
-        padding: 0.25em 0.5em;
-        border-radius: 5px;
-        z-index: 10;
-    }
-
-    .popup picture {
-        width: 120px;
-        height: 120px;
-    }
-
-    .show-logo {
-        width: 4em;
-        aspect-ratio: 1;
-        border-radius: 50px;
-    }
-
-    /* .popup-content {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-    } */
-
-    .popup-title{
-        margin-bottom: 1em;
-    }
-
-    .popup-buttons {
-        display: flex;
-        margin-top: 1em;
-    }
-
-    .popup-button {
-        flex: 1;
-        padding: 0.75rem 1rem;
-        border: none;
-        background: #007acc;
-        color: white;
-        cursor: pointer;
-    }
-
-    .popup-button:first-child {
-        border-radius: 0 0 0 5px;
-        background-color: #FE0170;
-    }
-
-    .popup-button:hover {
-        flex-grow: 2;
-    }
-
-    .popup-buttons:hover .popup-button:not(:hover) {
-        flex: 0;
-        display: none;
-    }
+ .popup-button:hover, .popup-button:focus {
+     flex: 1 1 100%;
+ }
 
 
-    /* .popup-buttons {
+
+
+ /* .popup-buttons {
         display: grid;
         grid-template-columns: 1fr 1fr;
 
@@ -134,7 +149,3 @@
             }
         }
     } */
-
-    .popup-button {
-        transition: grid-column 0.3s ease-in;
-    }

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -12,3 +12,5 @@
             openButton.focus();
         }
     });
+
+    

--- a/views/partials/popup.liquid
+++ b/views/partials/popup.liquid
@@ -1,6 +1,5 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<!-- anders blijft dit ***ding automatisch scalen -->
 
 
 <dialog class="popup" popover id="my-popover">
@@ -13,7 +12,7 @@
 
 
         <div class="popup-content">
-            <h3 class="popup-title">Show naam</h3>
+            <h3 class="popup-title">Ekdom in de morgen</h3>
             <dl>
                 <div class="info-wrapper">
                     <dt>
@@ -38,14 +37,6 @@
                     </dt>
                     <dd>Ekdom</dd> <!-- oneshow.from en until -->
                 </div>
-                <dt>
-                    <svg width="16px" height="16px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path fill-rule="evenodd" clip-rule="evenodd"
-                            d="M12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4ZM2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12ZM11.8284 6.75736C12.3807 6.75736 12.8284 7.20507 12.8284 7.75736V12.7245L16.3553 14.0653C16.8716 14.2615 17.131 14.8391 16.9347 15.3553C16.7385 15.8716 16.1609 16.131 15.6447 15.9347L11.4731 14.349C11.085 14.2014 10.8284 13.8294 10.8284 13.4142V7.75736C10.8284 7.20507 11.2761 6.75736 11.8284 6.75736Z"
-                            fill="#8B8B8B" />
-                    </svg>
-                </dt>
-                <dd>12:00 - 14:00</dd> <!-- oneshow.from en until -->
 
             </dl>
         </div>

--- a/views/partials/popup.liquid
+++ b/views/partials/popup.liquid
@@ -1,4 +1,3 @@
-
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 
@@ -6,6 +5,7 @@
 
     <div class="popup-layout">
         <strong class="popup-status">Bijna live!</strong>
+
         <picture class="show-logo">
             <img src="/assets/radioveronica-logo.png" alt="placeholder" height="120" width="120" />
         </picture>
@@ -14,25 +14,24 @@
         <div class="popup-content">
             <h3 class="popup-title">Ekdom in de morgen</h3>
             <dl>
-                    <dt>
-                        <svg width="16px" height="16px" viewBox="0 0 24 24" fill="none"
-                            xmlns="http://www.w3.org/2000/svg">
-                            <path fill-rule="evenodd" clip-rule="evenodd"
-                                d="M12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4ZM2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12ZM11.8284 6.75736C12.3807 6.75736 12.8284 7.20507 12.8284 7.75736V12.7245L16.3553 14.0653C16.8716 14.2615 17.131 14.8391 16.9347 15.3553C16.7385 15.8716 16.1609 16.131 15.6447 15.9347L11.4731 14.349C11.085 14.2014 10.8284 13.8294 10.8284 13.4142V7.75736C10.8284 7.20507 11.2761 6.75736 11.8284 6.75736Z"
-                                fill="#8B8B8B" />
-                        </svg>
-                    </dt>
-                    <dd>12:00 - 14:00</dd>
+                <dt>
+                    <svg width="16px" height="16px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path fill-rule="evenodd" clip-rule="evenodd"
+                            d="M12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4ZM2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12ZM11.8284 6.75736C12.3807 6.75736 12.8284 7.20507 12.8284 7.75736V12.7245L16.3553 14.0653C16.8716 14.2615 17.131 14.8391 16.9347 15.3553C16.7385 15.8716 16.1609 16.131 15.6447 15.9347L11.4731 14.349C11.085 14.2014 10.8284 13.8294 10.8284 13.4142V7.75736C10.8284 7.20507 11.2761 6.75736 11.8284 6.75736Z"
+                            fill="#8B8B8B" />
+                    </svg>
+                </dt>
+                <dd>12:00 - 14:00</dd>
 
-                    <dt>
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
-                            aria-hidden="true" focusable="false">
-                            <circle cx="12" cy="8" r="4" fill="#FFFFFF" />
-                            <path d="M4 20c0-4 4-6 8-6s8 2 8 6" stroke="#FFFFFF" stroke-width="2" fill="none"
-                                stroke-linecap="round" />
-                        </svg>
-                    </dt>
-                    <dd>Ekdom</dd> <!-- oneshow.from en until -->
+                <dt>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
+                        aria-hidden="true" focusable="false">
+                        <circle cx="12" cy="8" r="4" fill="#FFFFFF" />
+                        <path d="M4 20c0-4 4-6 8-6s8 2 8 6" stroke="#FFFFFF" stroke-width="2" fill="none"
+                            stroke-linecap="round" />
+                    </svg>
+                </dt>
+                <dd>Ekdom</dd> <!-- oneshow.from en until -->
 
             </dl>
         </div>
@@ -46,4 +45,5 @@
 
 </dialog>
 
-<button popovertarget="my-popover">Bekijk</button>
+
+        <button class="popup-button" popovertarget="my-popover">open popup</button>

--- a/views/partials/popup.liquid
+++ b/views/partials/popup.liquid
@@ -14,7 +14,6 @@
         <div class="popup-content">
             <h3 class="popup-title">Ekdom in de morgen</h3>
             <dl>
-                <div class="info-wrapper">
                     <dt>
                         <svg width="16px" height="16px" viewBox="0 0 24 24" fill="none"
                             xmlns="http://www.w3.org/2000/svg">
@@ -24,9 +23,7 @@
                         </svg>
                     </dt>
                     <dd>12:00 - 14:00</dd>
-                </div>
 
-                <div class="info-wrapper">
                     <dt>
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
                             aria-hidden="true" focusable="false">
@@ -36,7 +33,6 @@
                         </svg>
                     </dt>
                     <dd>Ekdom</dd> <!-- oneshow.from en until -->
-                </div>
 
             </dl>
         </div>

--- a/views/testpage.liquid
+++ b/views/testpage.liquid
@@ -1,4 +1,6 @@
 
+{% render 'partials/head.liquid' %}
+
 <body>
     {% render 'partials/popup.liquid' %}
 </body>


### PR DESCRIPTION
popup is nu dichter bij het design en een begin animatie is toegevoegd. 

nieuwe design:

![Schermafbeelding 2025-05-23 112154](https://github.com/user-attachments/assets/9fbf5ca8-570e-4ffd-8b33-d1066268d43b)
![Schermafbeelding 2025-05-23 112218](https://github.com/user-attachments/assets/cfa96133-26af-40be-859b-1edc2cd1ecba)

responsive test:
Met media querries is de popup responsive op mobiel desktop en tablet. In bovenstaande foto's is het resultaat te bekijken.

accessibility test:
een focus state voor mobiel toegevoegd omdat de bekijk button in de popup niet meer werkte als je deze sluit en opnieuw opent

alleen moet ik de goeie roze toevoegen (ben het kwijt)
![image](https://github.com/user-attachments/assets/2d9739ef-2a58-44be-81a0-8df98c9ae704)

performance:
De foto van veronica is te groot maar dit is een placeholder en word vervangen voor die uit de database. ik moet in de picture misschien in de toekomst alles naar webp omzetten

PE: zonder de styling werkt de popup nog steeds naar behoren de de popover en dialog


