### PR TITLE
Bookmarks delete button 18

### DIFF
--- a/public/css/bookmarks.css
+++ b/public/css/bookmarks.css
@@ -26,6 +26,20 @@ body.bookmarks .text-xxl{
     max-width: 380px;
     color: #fff;
 }
+/* DELETE BTN NEW */
+.container-bookmarks main .bookmarks-overview article button.bookmark-delete{
+    position: absolute;
+    top: 0;
+    left: 0;
+    translate: -50% -50%;
+    width: 40px;
+    height: 40px;
+    background: #B0120C;
+    border-radius: 50%;
+    appearance: none;
+    border: 3px solid #fff;
+}
+/*  */
 .container-bookmarks main .bookmarks-overview article svg > *{
     fill: #fff;
 }
@@ -120,6 +134,8 @@ body.bookmarks .text-xxl{
 dl {
   display: flex;
   flex-wrap: wrap;
+  font-size: 18px;
+  font-weight: bold;
 }
 dt {
   width: 1rem;

--- a/public/css/bookmarks.css
+++ b/public/css/bookmarks.css
@@ -27,11 +27,17 @@ body.bookmarks .text-xxl{
     color: #fff;
 }
 /* DELETE BTN NEW */
-.container-bookmarks main .bookmarks-overview article button.bookmark-delete{
+.container-bookmarks main .bookmarks-overview article form{
     position: absolute;
     top: 0;
     left: 0;
-    translate: -50% -50%;
+}
+@media (min-width: 500px){
+    .container-bookmarks main .bookmarks-overview article form{
+        translate: -50% -50%;
+    }
+}
+.container-bookmarks main .bookmarks-overview article form button.bookmark-delete{
     width: 40px;
     height: 40px;
     background: #B0120C;

--- a/views/bookmarks.liquid
+++ b/views/bookmarks.liquid
@@ -2,36 +2,6 @@
 
 <body class="bookmarks">
     <div class="container-bookmarks">
-        <main>
-            <svg width="45" height="45" viewBox="0 0 93 93" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M73.625 23.25C73.625 16.8297 68.4203 11.625 62 11.625H31C24.5795 11.625 19.375 16.8297 19.375 23.25V77.7201C19.375 80.872 22.9377 82.7053 25.5021 80.8732L44.2479 67.4839C45.5952 66.5213 47.4048 66.5213 48.7521 67.4839L67.4977 80.8732C70.0624 82.7053 73.625 80.872 73.625 77.7201V23.25Z" stroke="#1E1E1E" stroke-width="6.67"/></svg>
-            <h1 class="text-xxl">Bookmarks</h1>
-            <section class="bookmarks-overview">
-
-                {% for bookmark in bookmarks limit: 3%} 
-                    <article class="radio-{{bookmark.show.radiostation.id}}"> {% comment %} hier moet het nummer van de radiostation komen {% endcomment %}
-                        <p class="bookmark-label">{{ bookmark.show.radiostation.name }}</p>
-                        <picture>
-                            <source srcset="https://fdnd-agency.directus.app/assets/{{ bookmark.show.headermobile.id }}">
-                            <img src="https://fdnd-agency.directus.app/assets/{{ bookmark.show.headermobile.id }}" alt="{{ bookmark.show.headermobile.title }}" width="800">
-                        </picture>
-                        <div class="bookmark-content">
-                            <h2 class="text-xl">{{ bookmark.show.name }}</h2>
-                            <dl>
-                                <dt><svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4ZM2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12ZM11.8284 6.75736C12.3807 6.75736 12.8284 7.20507 12.8284 7.75736V12.7245L16.3553 14.0653C16.8716 14.2615 17.131 14.8391 16.9347 15.3553C16.7385 15.8716 16.1609 16.131 15.6447 15.9347L11.4731 14.349C11.085 14.2014 10.8284 13.8294 10.8284 13.4142V7.75736C10.8284 7.20507 11.2761 6.75736 11.8284 6.75736Z" fill="#8B8B8B"/></svg></dt>
-                                <dd>{{ bookmark.from }} - {{ bookmark.until }}</dd>
-                                <dt>
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 16 16" fill="none">
-                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M11.3333 5.33333C11.3333 7.17333 9.84 8.66667 8 8.66667C6.16 8.66667 4.66667 7.17333 4.66667 5.33333C4.66667 3.49333 6.16 2 8 2C9.84 2 11.3333 3.49333 11.3333 5.33333ZM10 5.33333C10 4.23333 9.1 3.33333 8 3.33333C6.9 3.33333 6 4.23333 6 5.33333C6 6.43333 6.9 7.33333 8 7.33333C9.1 7.33333 10 6.43333 10 5.33333ZM2 14.6667V10H14V14.6667H2ZM3.33333 11.3333V13.3333H12.6667V11.3333H3.33333Z" fill="#8B8B8B"/>
-                                    </svg>                            </dt>
-                                <dd>{{ bookmark.show.name }}</dd>
-                            </dl>
-                        </div>
-                        
-                    </article>
-                {% endfor %}
-                                
-            </section>
-        </main>
         <aside>
             <svg width="45" height="45" viewBox="0 0 97 97" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M85.7116 30.3127H18.8392L43.0773 9.10435C44.7572 7.63438 44.9273 5.08112 43.4575 3.40124C41.9875 1.72136 39.4343 1.55123 37.7544 3.02101L5.42101 31.3128C4.9847 31.6945 4.65259 32.1504 4.42221 32.6441C1.73444 34.7076 0 37.9514 0 41.6011V75.6077C0 80.7271 3.41072 85.0491 8.08245 86.4313V90.9377C8.08245 93.1698 9.89192 94.9793 12.1241 94.9793C14.3562 94.9793 16.1657 93.1698 16.1657 90.9377V86.8961H80.8323V90.9377C80.8323 93.1698 82.6417 94.9793 84.8739 94.9793C87.106 94.9793 88.9155 93.1698 88.9155 90.9377V86.4317C93.5885 85.05 97 80.7277 97 75.6077V41.6011C97 35.3677 91.945 30.3127 85.7116 30.3127ZM88.9166 75.6077C88.9166 77.3768 87.4807 78.8127 85.7116 78.8127H11.2884C9.51926 78.8127 8.0834 77.3768 8.0834 75.6077V41.6011C8.0834 39.8319 9.51926 38.3961 11.2884 38.3961H85.7116C87.4807 38.3961 88.9166 39.8319 88.9166 41.6011V75.6077Z" fill="white"/><path d="M60.6241 46.4795H36.3741C34.142 46.4795 32.3325 48.289 32.3325 50.5211V66.6879C32.3325 68.92 34.142 70.7295 36.3741 70.7295H60.6241C62.8563 70.7295 64.6657 68.92 64.6657 66.6879V50.5213C64.6657 48.2891 62.8563 46.4795 60.6241 46.4795ZM56.5823 62.6463H40.4157V54.5629H56.5823V62.6463Z" fill="white"/><path d="M20.2074 62.646C17.9764 62.646 16.1658 64.4566 16.1658 66.6876C16.1658 68.9186 17.9764 70.7292 20.2074 70.7292C22.4384 70.7292 24.249 68.9186 24.249 66.6876C24.249 64.4566 22.4384 62.646 20.2074 62.646Z" fill="white"/><path d="M20.2074 46.4795C17.9764 46.4795 16.1658 48.2901 16.1658 50.5211C16.1658 52.7521 17.9764 54.5629 20.2074 54.5629C22.4384 54.5629 24.249 52.7523 24.249 50.5213C24.249 48.2903 22.4384 46.4795 20.2074 46.4795Z" fill="white"/><path d="M76.7909 62.646C74.5599 62.646 72.7493 64.4566 72.7493 66.6876C72.7493 68.9186 74.5599 70.7292 76.7909 70.7292C79.0219 70.7292 80.8325 68.9186 80.8325 66.6876C80.8325 64.4566 79.0219 62.646 76.7909 62.646Z" fill="white"/><path d="M76.7909 46.4795C74.5599 46.4795 72.7493 48.2901 72.7493 50.5211C72.7493 52.7521 74.5599 54.5629 76.7909 54.5629C79.0219 54.5629 80.8325 52.7523 80.8325 50.5213C80.8325 48.2903 79.0219 46.4795 76.7909 46.4795Z" fill="white"/></svg>
             <h2 class="text-xxl">Radiostations</h2>
@@ -70,5 +40,42 @@
                 </ul>
             </nav>
         </aside>
+        <main>
+            <svg width="45" height="45" viewBox="0 0 93 93" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M73.625 23.25C73.625 16.8297 68.4203 11.625 62 11.625H31C24.5795 11.625 19.375 16.8297 19.375 23.25V77.7201C19.375 80.872 22.9377 82.7053 25.5021 80.8732L44.2479 67.4839C45.5952 66.5213 47.4048 66.5213 48.7521 67.4839L67.4977 80.8732C70.0624 82.7053 73.625 80.872 73.625 77.7201V23.25Z" stroke="#1E1E1E" stroke-width="6.67"/></svg>
+            <h1 class="text-xxl">Bookmarks</h1>
+            <section class="bookmarks-overview">
+
+                {% for bookmark in bookmarks limit: 3%} 
+                    <article class="radio-{{bookmark.show.radiostation.id}}"> {% comment %} hier moet het nummer van de radiostation komen {% endcomment %}
+                        <p class="bookmark-label">{{ bookmark.show.radiostation.name }}</p>
+                        <picture>
+                            <source srcset="https://fdnd-agency.directus.app/assets/{{ bookmark.show.headermobile.id }}">
+                            <img src="https://fdnd-agency.directus.app/assets/{{ bookmark.show.headermobile.id }}" alt="{{ bookmark.show.headermobile.title }}" width="{{ bookmark.show.headermobile.width }}" height="{{ bookmark.show.headermobile.height }}">
+                        </picture>
+                        <div class="bookmark-content">
+                            <h2 class="text-xl">{{ bookmark.show.name }}</h2>
+                            <dl>
+                                <dt><svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4ZM2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12ZM11.8284 6.75736C12.3807 6.75736 12.8284 7.20507 12.8284 7.75736V12.7245L16.3553 14.0653C16.8716 14.2615 17.131 14.8391 16.9347 15.3553C16.7385 15.8716 16.1609 16.131 15.6447 15.9347L11.4731 14.349C11.085 14.2014 10.8284 13.8294 10.8284 13.4142V7.75736C10.8284 7.20507 11.2761 6.75736 11.8284 6.75736Z" fill="#8B8B8B"/></svg></dt>
+                                <dd>{{ bookmark.from }} - {{ bookmark.until }}</dd>
+                                <dt>
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 16 16" fill="none">
+                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M11.3333 5.33333C11.3333 7.17333 9.84 8.66667 8 8.66667C6.16 8.66667 4.66667 7.17333 4.66667 5.33333C4.66667 3.49333 6.16 2 8 2C9.84 2 11.3333 3.49333 11.3333 5.33333ZM10 5.33333C10 4.23333 9.1 3.33333 8 3.33333C6.9 3.33333 6 4.23333 6 5.33333C6 6.43333 6.9 7.33333 8 7.33333C9.1 7.33333 10 6.43333 10 5.33333ZM2 14.6667V10H14V14.6667H2ZM3.33333 11.3333V13.3333H12.6667V11.3333H3.33333Z" fill="#8B8B8B"/>
+                                    </svg>                            </dt>
+                                <dd>{{ bookmark.show.name }}</dd>
+                            </dl>
+                        </div>
+                        <form method="post" data-enhanced="{{deejay.mh_users_id.id}}" class="form-rating" action="/radio/{{stationNameGeneratedEncoded}}/programmering/{{bookmark.show.name}}/unmark">         
+                            <button class="bookmark-delete" type="submit" value="Unlike">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" width="16" height="20">
+                                    <path d="M135.2 17.7L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-7.2-14.3C307.4 6.8 296.3 0 284.2 0L163.8 0c-12.1 0-23.2 6.8-28.6 17.7zM416 128L32 128 53.2 467c1.6 25.3 22.6 45 47.9 45l245.8 0c25.3 0 46.3-19.7 47.9-45L416 128z"/>
+                                    <title>Verwijder Bookmark</title>
+                                </svg>
+                            </button>                 
+                        </form>
+                    </article>
+                {% endfor %}
+                                
+            </section>
+        </main>
     </div>
 </body>


### PR DESCRIPTION
Titel: added unmark button and removes two performance issues

Bookmark page
 
 ⸻
 
## Beschrijving van de wijziging

Ik heb de unmark button toegevoegd aan de bookmark cards
 
Een korte samenvatting van de wijzigingen en welke tests zijn uitgevoerd.
 
Leg ontwerp keuzes uit aan de hand van Hierarchy of User Needs.
Link naar je ontwerp in Figma.
 
⸻
 
Screenshots / Video
 

 
![Screenshot (386)](https://github.com/user-attachments/assets/af99a15b-d58a-4aec-b32a-21e2e69b0882)

![Screenshot (387)](https://github.com/user-attachments/assets/9341dda5-e68e-4559-b213-d52228498966)

⸻
 
## Checklist (RAPPE)
### Responsive 
Ik had nog even mijn bebsite bekeken op mobile, toen viel mij iets op:

![Screenshot (387)](https://github.com/user-attachments/assets/378aeb7e-24cb-4930-89e5-7500be8a7cae)

Ik kwam erachter dat mijn translate CSS buiten de view viel op mobiel. Deze translate heb ik hierna in een min-width media query geplaatst

## Accessible

Ik had een lighthouse-test gedaan en een keyboard test.

Tijdens de keyboard test kwam ik erachter dat de main en aside verkeerd om zaten (volgensmij had ik dit veranderd, sorry @Clarice-COD  :)  ). Hierdoor klopte de tabindex niet, dus dit heb ik gefixed.
Zie hieronder:
https://github.com/ColindeGroot/pleasurable-ui/compare/main...bookmarks-delete-button-18?expand=1#diff-8021204b8ec613040a24bf71d53b7ed26b053bd36c6c2992dd3601ae6d8a2d0aL5-L35

 Verder heb ik nog een screenreader test gedaan. Deze kwam ook niet door de test heen. Bij de logo's van de radiostations in de aside riep hij niet om, om welk logo het ging. Dit is hier ook te zien aan de hand van de DOM code:
  
![Screenshot (389)](https://github.com/user-attachments/assets/ff02522e-a37a-439e-98c4-572cdda9a5f5)

P.S. Ook de link klopte niet, heb ik aangepast.

Ik heb de variabelen van de radiostation title saangepast naar de correcte datapoint, en toen werkte het

Performant

Over het algemeen is de performance goed. Er waren twee problemeen, waarvan ik er een heb weten op te lossen.

De breedtes en hoogtes van de show images uit de database hadden nog niet de correcte hoogte en breedte. Hierdor was er een layout shift. Dit heb ik opgelost:

```
<img src="https://fdnd-agency.directus.app/assets/{{ bookmark.show.headermobile.id }}" alt="{{ bookmark.show.headermobile.title }}" width="{{ bookmark.show.headermobile.width }}" height="{{ bookmark.show.headermobile.height }}">
```

Progressive Enhanced: Zonder CSS zie je enkel een button met een vuilnisbakje erin, zonder label.

Ik had er nog over nagedacht om een label toe te voegen en heb hiermee geexperimnenteerd.
Ik vond het alleen niet zo mooi, maar misschien moet ik dit op een andere manier doen (misschien alleen een label in prototype???:

![Screenshot (385)](https://github.com/user-attachments/assets/150e1f0e-b52a-4087-b3bd-b4da294e7e99)

 
⸻
 
Feedback
 
@Clarice-COD  Wat vind je hiervan?

Ik heb een vraag. Bij de bookmark delete button roept de schermlezer alleen bij de link om: verwijder bookmark. Hoe kunnen we de bookmark kaartjes en/of de verwijderknop beter toegankelijk maken voor schermlezers? Weret even niet wat er nog toegevoegd kan worden hier.
 
⸻
 
Verwijs issues
 
[Verwijs naar relevante issues in GitHub](https://github.com/ColindeGroot/pleasurable-ui/issues/18#issuecomment-2902953918)